### PR TITLE
.env ファイルを置けるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.swp
 *.bak
 *.orig
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "lita"
+gem 'lita-dotenv'
 gem "lita-slack"
 
 gem "lita-suddendeath", path: './lita-suddendeath'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    dotenv (2.0.2)
     eventmachine (1.0.8)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
@@ -43,6 +44,9 @@ GEM
       rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
+    lita-dotenv (0.9.0)
+      dotenv (~> 2.0)
+      lita (>= 4.4)
     lita-slack (1.5.0)
       eventmachine
       faraday
@@ -70,6 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   lita
+  lita-dotenv
   lita-fight!
   lita-ping!
   lita-slack


### PR DESCRIPTION
開発時に自分用の Slack API token を使えるようにしました。
トップディレクトリに .env というファイルを設置して

```
SLACK_API_KEY=YOUR_SLACK_API_TOKEN
REDISTOGO_URL='redis://localhost:6379'
PORT=8080
```

みたいに書いておけばokです。

Heroku にデプロイする用は特に何も考えなくて大丈夫なはず。
